### PR TITLE
Update outdated note in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Showybox** is a Typst package for creating colorful and customizable boxes.
 
-_Please note that this version (v.0.3.0) **isn't yet published at Typst's official package repository**. If you want to use this package, see https://github.com/typst/packages/tree/main/packages/preview for the latest stable version_
+_Please note that this repository contains the latest (development) version of this package and **may not yet be published at Typst's official package repository**. If you want to use this package, see https://github.com/typst/packages/tree/main/packages/preview for the latest stable version_
 
 ## Usage
 


### PR DESCRIPTION
The note was still referencing version 0.3.0. It has now been reworded to not be specific to any version.