### PR TITLE
Updated version in typst.toml

### DIFF
--- a/typst.toml
+++ b/typst.toml
@@ -1,6 +1,6 @@
 [package]
 name = "showybox"
-version = "1.0.0"
+version = "1.2.0"
 entrypoint = "showy.typ"
 authors = ["Pablo González Calderón", "Showybox Contributors"]
 license = "MIT"


### PR DESCRIPTION
Current version in `README.md` is `1.2.0`, but `typst.toml` has `1.0.0`.

P.S. Which means, that version `1.1.0` also had `1.0.0` in `typst.toml`.